### PR TITLE
Default to blocking updates when kmod isn't in the repos

### DIFF
--- a/dnf-plugin-protected-kmods.spec
+++ b/dnf-plugin-protected-kmods.spec
@@ -46,6 +46,8 @@ install -m 0644 README %{buildroot}%{_docdir}/dnf-plugin-protected-kmods/
 %changelog
 * Fri Mar 07 2025 Jonathan Dieter <jdieter@ciq.com> - 0.9-1
 - Speed up filtering when there are a large number of kernels
+- Change default to enforce a kmod blocking kernel updates, even when the kmod
+  isn't in a repo
 
 * Mon Jan 13 2025 Jonathan Dieter <jdieter@ciq.com> - 0.8-1
 - Temporarily disable plugin when available package sack isn't populated

--- a/tests/tests.d/07-test-kernel3-update-kmod-not-in-repo.sh
+++ b/tests/tests.d/07-test-kernel3-update-kmod-not-in-repo.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+. ../test-common.sh
+
+# Test that kernel3 update is hidden when no kmod-test is in the repos
+copy_packages kernel1 test7a
+copy_packages kernel2 test7a
+mkrepo test7a
+mkdnfconfig test7a
+copy_packages kmod-test1 test7b
+mkrepo test7b
+mkdnfconfig test7b
+installpkg kmod-test
+copy_packages kernel3 test7a
+mkrepo test7a
+testdnfcmd test7b " --disablerepo=test7b -y update" "INFO: kmod-test: filtering kernel 6.0.0-3, no precompiled modules available" "kernel *x86_64 *6.0.0-2 *test7a" "Install.* 4 [Pp]ackages" '^Complete!$'
+cleanup
+exitcode

--- a/tests/tests.d/08-test-kernel3-update-kmod-not-in-repo-config-flag-false.sh
+++ b/tests/tests.d/08-test-kernel3-update-kmod-not-in-repo-config-flag-false.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+. ../test-common.sh
+
+# Test that kernel3 update works when no kmod-test is in the repos, but block_updates_when_kmod_not_in_repos is False
+cat << EOF > /etc/dnf/plugins/protected-kmods.conf
+[main]
+block_updates_when_kmod_not_in_repos = False
+EOF
+copy_packages kernel1 test7a
+copy_packages kernel2 test7a
+mkrepo test7a
+mkdnfconfig test7a
+copy_packages kmod-test1 test7b
+mkrepo test7b
+mkdnfconfig test7b
+installpkg kmod-test
+copy_packages kernel3 test7a
+mkrepo test7a
+testdnfcmd test7b " --disablerepo=test7b -y update" "WARNING: No kmod-test packages available in the repositories, so not blocking updates based on kmod-test." "kernel *x86_64 *6.0.0-3 *test7a" "Install.* 4 [Pp]ackages" '^Complete!$'
+cleanup
+rm -f /etc/dnf/plugins/protected-kmods.conf
+exitcode


### PR DESCRIPTION
After some discussion, we decided that it is less surprising for users to have an orphaned kmod (one that isn't in the repos) block kernel updates as opposed to having the kernel be updated and the orphaned kmod broken.

For those who, (possibly for security reasons) would prefer the original behavior, /etc/dnf/plugins/protected-kmods.conf can be modified as follows:

```
[main]
block_updates_when_kmod_not_in_repos = False
```