### PR TITLE
Handle kmods for installed kernels

### DIFF
--- a/dnf-plugin-protected-kmods.spec
+++ b/dnf-plugin-protected-kmods.spec
@@ -1,5 +1,5 @@
 Name:       dnf-plugin-protected-kmods
-Version:    0.9.3
+Version:    0.9.4
 Release:    1%{?dist}
 Summary:    DNF plugin needed to protect kmods
 License:    Apache-2.0
@@ -45,5 +45,5 @@ install -D -m 644 src/protected_kmods.py %{buildroot}%{python3_sitelib}/dnf-plug
 
 
 %changelog
-* Sat Jun 07 2025 Jonathan Dieter <jdieter@ciq.com> - 0.9.3-1
+* Mon Jun 16 2025 Jonathan Dieter <jdieter@ciq.com> - 0.9.4-1
 - Initial release for EPEL

--- a/tests/test-common.sh
+++ b/tests/test-common.sh
@@ -13,6 +13,11 @@ function mkrepo {
     popd
 }
 
+function rmrepo {
+    # Remove repository at $1
+    rm -rf /var/tmp/repos/"$1"
+}
+
 function mkdnfconfig {
     # Create repo file at $1
     cat << EOF > /etc/yum.repos.d/"$1".repo
@@ -22,6 +27,11 @@ baseurl=file:///var/tmp/repos/$1
 gpgcheck=0
 enabled=1
 EOF
+}
+
+function rmdnfconfig {
+    # Remove repo file at $1
+    rm -f /etc/yum.repos.d/"$1".repo
 }
 
 function snapshotpkgs {

--- a/tests/tests.d/09-test-kernel3-installed-only-update-new-kmod.sh
+++ b/tests/tests.d/09-test-kernel3-installed-only-update-new-kmod.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+. ../test-common.sh
+
+# Test that everything updates when latest kmod-test and kernel have matching symbols
+copy_packages kernel1 test9
+copy_packages kmod-test1 test9
+mkrepo test9
+mkdnfconfig test9
+installpkg kernel
+installpkg kmod-test
+rmrepo test9
+copy_packages kernel3 test9
+mkrepo test9
+dnf -y --refresh --disableplugin=protected-kmods update kernel
+rmrepo test9
+copy_packages kmod-test2 test9
+mkrepo test9
+testdnf test9 "Upgrading *: *kmod-test-1.0-2.x86_64"
+cleanup
+exitcode


### PR DESCRIPTION
Currently, kmods will be excluded if they don't match an available kernel, even if they do match an _installed_ kernel.  This is counterintuitive, so this PR ensures that kmods aren't excluded if they work with an installed kernel.